### PR TITLE
No libraries with repeated names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ start:
 spellcheck:
 	./scripts/spellcheck.sh
 
-test:
+test: clean-test
 	POETRY_DOTENV_LOCATION="$(shell pwd)/test.env" poetry run pytest
-	POETRY_DOTENV_LOCATION="$(shell pwd)/test.env" poetry run python scripts/clean_test_db.py
-
+	
+clean-test:
+	POETRY_DOTENV_LOCATION="$(shell pwd)/test.env" poetry run python scripts/clean_test_db.py	
 
 test-nodb:
 	TEST="test" poetry run pytest

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ spellcheck:
 
 test:
 	POETRY_DOTENV_LOCATION="$(shell pwd)/test.env" poetry run pytest
+	POETRY_DOTENV_LOCATION="$(shell pwd)/test.env" poetry run python scripts/clean_test_db.py
+
 
 test-nodb:
 	TEST="test" poetry run pytest

--- a/mmr-backend/api.py
+++ b/mmr-backend/api.py
@@ -69,6 +69,8 @@ async def add_library_entry(user: str, library_name: str, isbn: str, response: R
     success: bool = data_manager.add_library_entry(user, library_name, isbn)
     if success:
         response.status_code = status.HTTP_201_CREATED
+    else:
+        response.status_code = status.HTTP_409_CONFLICT
 
 
 @mmr.delete("/libraries/{user}/{library_name}/{isbn}")

--- a/mmr-backend/api.py
+++ b/mmr-backend/api.py
@@ -126,11 +126,16 @@ async def add_user_recommendation(isbn1: str, isbn2: str, user: str, comment: st
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {"error": "Can't recommend a book with itself"}
 
-    if not data_manager.create_user_recommendation(isbn1, isbn2, user, comment):
+    result: int = data_manager.create_user_recommendation(
+        isbn1, isbn2, user, comment)
+
+    if result == 404:
         response.status_code = status.HTTP_404_NOT_FOUND
         return {"error": "Can't find some of the indicated books"}
-
-    response.status_code = status.HTTP_201_CREATED
-    response.headers["location"] = "/recommendations/" + \
-        "/".join((isbn1, isbn2, user))
+    elif result == 409:
+        response.status_code = status.HTTP_409_CONFLICT
+    else:
+        response.status_code = status.HTTP_201_CREATED
+        response.headers["location"] = "/recommendations/" + \
+            "/".join((isbn1, isbn2, user))
     return None

--- a/mmr-backend/api.py
+++ b/mmr-backend/api.py
@@ -56,9 +56,12 @@ async def update_library_name(user: str, library_name: str, new_name: str) -> No
 
 @mmr.post("/libraries/{user}/{library_name}")
 async def create_library(user: str, library_name: str, response: Response) -> None:
-    data_manager.create_library(user, library_name)
-    response.status_code = status.HTTP_201_CREATED
-    response.headers["location"] = "/libraries/"+user+"/"+library_name
+    success = data_manager.create_library(user, library_name)
+    if success:
+        response.status_code = status.HTTP_201_CREATED
+        response.headers["location"] = "/libraries/"+user+"/"+library_name
+    else:
+        response.status_code = status.HTTP_409_CONFLICT
 
 
 @mmr.post("/libraries/{user}/{library_name}/{isbn}")

--- a/mmr-backend/data_manager.py
+++ b/mmr-backend/data_manager.py
@@ -125,10 +125,12 @@ class DataManager:
     def delete_library(self, user: str, library_name: str) -> None:
         self._cur.execute(
             "delete from libraries where owner = %s and name = %s", (user, library_name))
+        self._connection.commit()
 
     def rename_library(self, user: str, library_name: str, new_name: str) -> None:
         self._cur.execute(
             "update libraries set name = %s where owner = %s and name = %s", (new_name, user, library_name))
+        self._connection.commit()
 
     def create_library(self, user: str, library_name: str) -> bool:
         try:
@@ -146,12 +148,14 @@ class DataManager:
         self._cur.execute("delete from library_entries le using libraries l, books b " +
                           "where le.library_id = l.id and b.id = le.book_id and " +
                           "b.isbn = %s and l.owner = %s and l.name = %s", (isbn, user, library_name))
+        self._connection.commit()
 
     def add_library_entry(self, user: str, library_name: str, isbn: str) -> bool:
         self._cur.execute("insert into library_entries(library_id, book_id) " +
                           "select l.id, b.id from libraries l, books b " +
                           "where l.owner = %s AND l.name = %s AND b.isbn = %s " +
                           "returning id", (user, library_name, isbn))
+        self._connection.commit()
         success = self._cur.fetchone()
         return True if success else False
 
@@ -160,6 +164,7 @@ class DataManager:
                           "from books b, libraries l " +
                           "where l.owner = %s AND l.name = %s AND b.isbn = %s " +
                           "AND le.library_id = l.id AND le.book_id = b.id", (score, status.value, user, library_name, isbn))
+        self._connection.commit()
 
     # RECOMMENDATIONS
 
@@ -217,6 +222,7 @@ class DataManager:
                           "values " +
                           "(%s, %s, %s) " +
                           "returning id", (recommendationPairId, user, comment))
+        self._connection.commit()
         result = self._cur.fetchone()
         return True if result else False
 
@@ -229,5 +235,6 @@ class DataManager:
                           "on (ur.book1_id = b1.id and ur.book2_id = b2.id) or (ur.book1_id = b2.id and ur.book2_id = b1.id) " +
                           "where ur.id = urc.recommendation_id and urc.author = %s " +
                           "returning urc.id", (isbn1, isbn2, user))
+        self._connection.commit()
         result = self._cur.fetchone()
         return True if result else False

--- a/mmr-backend/test/mock_data_manager.py
+++ b/mmr-backend/test/mock_data_manager.py
@@ -107,18 +107,21 @@ class DataManager:
         book1: Optional[Book] = self.get_book(isbn1)
         book2: Optional[Book] = self.get_book(isbn2)
         if not (book1 and book2):
-            return False
+            return 404
 
         recommendations: list[UserRecommendation] = list(filter(lambda recommendation: recommendation.has_book(
             isbn1) and recommendation.has_book(isbn2), self.fake_recommendations))
 
         if len(recommendations):
+            for recommendation in recommendations:
+                if len(recommendation.get_author_comments(user)) > 0:
+                    return 409
             recommendations[0].add_comment(
                 UserRecommendation.UserComment(user, comment))
         else:
             self.fake_recommendations.append(UserRecommendation(
                 (isbn1, isbn2), UserRecommendation.UserComment(user, comment)))
-        return True
+        return 201
 
     def vote_user_recommendation(self, isbn1: str, isbn2: str, user: str) -> bool:
         book1: Optional[Book] = self.get_book(isbn1)

--- a/mmr-backend/test/mock_data_manager.py
+++ b/mmr-backend/test/mock_data_manager.py
@@ -82,6 +82,9 @@ class DataManager:
         book: Optional[Book] = self.get_book(isbn)
         library: Optional[Library] = self.get_library(user, library_name)
         if book and library:
+            for entry in library.get_entries():
+                if entry.get_book_id() == isbn:
+                    return False
             library.add_entry(Library.Entry(book, None, ""))
         return bool(book and library)
 

--- a/mmr-backend/test/mock_data_manager.py
+++ b/mmr-backend/test/mock_data_manager.py
@@ -13,7 +13,7 @@ data_path = os.path.join(current_dir, sample_data_path)
 
 class DataManager:
     def __init__(self) -> None:
-         # Set up fake data until real database is implemented
+        # Set up fake data until real database is implemented
         books_data = open(data_path)
         self.fake_books = json.load(books_data)
         books_data.close()
@@ -63,9 +63,13 @@ class DataManager:
         if library:
             library.set_name(new_name)
 
-    def create_library(self, user: str, library_name: str) -> None:
+    def create_library(self, user: str, library_name: str) -> bool:
         # To be replaced by an actual query
+        for library in self.fake_libraries:
+            if library.get_owner() == user and library.get_name() == library_name:
+                return False
         self.fake_libraries.append(Library(user, library_name, list()))
+        return True
 
     def remove_library_entry(self, user: str, library_name: str, isbn: str) -> None:
         # To be replaced by an actual query

--- a/mmr-backend/test/test_api.py
+++ b/mmr-backend/test/test_api.py
@@ -107,6 +107,16 @@ def test_create_library():
         [{"owner": "userTest", "name": "libraryTest", "entries": []}])
 
 
+def test_no_duplicated_libraries_for_an_user():
+    # Given - When
+    with TestClient(mmr) as client:
+        libraries = client.get("/libraries/userTest").json()
+        response = client.post("/libraries/userTest/"+libraries[0]["name"])
+
+    # Then
+    assert_that(response.status_code).is_equal_to(409)
+
+
 def test_update_library():
     # Given - When
     with TestClient(mmr) as client:

--- a/mmr-backend/test/test_api.py
+++ b/mmr-backend/test/test_api.py
@@ -359,6 +359,15 @@ def test_add_user_recommendation_existing():
     assert_that(new_recommendations).is_equal_to(expected_new_recommendations)
 
 
+def test_add_user_recommendation_one_comment_per_user():
+    # Given - When
+    with TestClient(mmr) as client:
+        response = client.post(
+            "/recommendations/99921-58-10-7/0-9752298-0-X/username/comment")
+    # Then
+    assert_that(response.status_code).is_equal_to(409)
+
+
 def test_recommendations_from_library():
     # Given
     expected_recommendaitons = [

--- a/mmr-backend/test/test_api.py
+++ b/mmr-backend/test/test_api.py
@@ -170,6 +170,15 @@ def test_library_add_entry():
         [{"book": book_list[0].to_dict(), "score": None, "status": ""}])
 
 
+def test_library_no_duplicated_entries():
+    # Given - When
+    with TestClient(mmr) as client:
+        response = client.post("/libraries/user1/myLibrary/99921-58-10-7")
+
+    # Then
+    assert_that(response.status_code).is_equal_to(409)
+
+
 def test_library_update_entry():
     # Given - When
     with TestClient(mmr) as client:

--- a/scripts/clean_test_db.py
+++ b/scripts/clean_test_db.py
@@ -1,0 +1,17 @@
+import psycopg2
+import psycopg2.extras
+from os import environ
+
+connection = psycopg2.connect(host=environ.get("HOST"),
+                              database=environ.get("DATABASE"),
+                              user=environ.get("USER"),
+                              password=environ.get("PASSWORD"),
+                              port=environ.get("PORT"))
+cur = connection.cursor(
+    cursor_factory=psycopg2.extras.RealDictCursor)
+
+cur.execute("delete from libraries where id>3;")
+cur.execute(
+    "delete from user_recommendation_comments where id>2;")
+cur.execute("delete from user_recommendations where id>2;")
+connection.commit()

--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -11,30 +11,36 @@ CREATE TABLE books (
 CREATE TABLE authors (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
-    birth_date DATE NOT NULL
+    birth_date DATE NOT NULL,
+    UNIQUE(name, birth_date)
 );
 
 CREATE TABLE genres (
     id SERIAL PRIMARY KEY,
-    genre TEXT NOT NULL
+    genre TEXT NOT NULL,
+    UNIQUE(genre)
 );
 
 CREATE TABLE authored (
     id SERIAL PRIMARY KEY,
     book_id INTEGER REFERENCES books (id),
-    author_id INTEGER REFERENCES authors (id)
+    author_id INTEGER REFERENCES authors (id),
+    UNIQUE(book_id, author_id)
 );
 
 CREATE TABLE book_genres (
     id SERIAL PRIMARY KEY,
     book_id INTEGER REFERENCES books (id),
-    genre_id INTEGER REFERENCES genres (id)
+    genre_id INTEGER REFERENCES genres (id),
+    UNIQUE(book_id, genre_id)
+
 );
 
 CREATE TABLE libraries (
     id SERIAL PRIMARY KEY,
     owner TEXT NOT NULL,
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    UNIQUE(owner, name)
 );
 
 CREATE TYPE ReadingStatus AS ENUM ('PLAN_TO_READ', 'CURRENTLY_READING', 'COMPLETED', 'DROPPED', 'ON_HOLD', '');
@@ -44,14 +50,16 @@ CREATE TABLE library_entries (
     library_id INTEGER REFERENCES libraries (id) ON DELETE CASCADE,
     book_id INTEGER REFERENCES books (id),
     score INTEGER,
-    reading_status ReadingStatus NOT NULL DEFAULT ''
+    reading_status ReadingStatus NOT NULL DEFAULT '',
+    UNIQUE(library_id, book_id)
 );
 
 CREATE TABLE user_recommendations (
     id SERIAL PRIMARY KEY,
     book1_id INTEGER REFERENCES books (id),
     book2_id INTEGER REFERENCES books (id),
-    CHECK (book1_id <> book2_id)
+    CHECK (book1_id <> book2_id),
+    UNIQUE(book1_id, book2_id)
 );
 
 CREATE TABLE user_recommendation_comments (
@@ -59,7 +67,8 @@ CREATE TABLE user_recommendation_comments (
     recommendation_id INTEGER REFERENCES user_recommendations (id),
     author TEXT NOT NULL,
     comment TEXT NOT NULL,
-    score INTEGER NOT NULL DEFAULT 0
+    score INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(recommendation_id, author)
 );
 
 insert into genres(genre) values ('Action'), --1


### PR DESCRIPTION
In #93 I found the issue that the DB allowed duplicated information that could affect consistency.

This PR includes changes in the DB to avoid these possible duplicities, and adds the logic accordingly to the DataManager class to handle these situations, resulting in a different HTTP response code from the API.

During the development I found out that the DataManager was not commiting the changes to the DB, so all these changes were not stored. This resulted in also noticing that after tests execution on the test DB were not restoring the initial test DB status, so I created a script and added it to the test target to clean the DB before each execution.

Closes #102 
Closes #93
Related to US #98 