### PR TITLE
Remove jury persona from docs as it is not relevant for development

### DIFF
--- a/docs/tex/secciones/04_analisis.tex
+++ b/docs/tex/secciones/04_analisis.tex
@@ -65,25 +65,6 @@ En primer lugar, una lista de \textit{personas} aportará una idea general de qu
     \end{tabularx}
 \end{table}
 
-\begin{table}[H]
-    \centering
-    \begin{tabularx}{\columnwidth}{|l|X|}
-        \hline
-        \textbf{Nombre y edad} & Javier, 36 años. \\
-        \hline
-        \textbf{Rol} & Miembro del tribunal. \\
-        \hline
-        \textbf{Ocupación} & Profesor en la Universidad de Granada. \\
-        \hline
-        \textbf{Biografía} & Siempre llega una época en la que Javier debe dedicar más tiempo a su trabajo, leyendo todos los TFG y TFM que le han sido asignados. Siempre muestra curiosidad por éstos, ya que no es raro encontrar alguno del que aprender algo nuevo, conocer nuevos puntos de vista o metodologías, aunque la carga de trabajo hace que le cueste un esfuerzo adicional realizar estas revisiones. \\
-        \hline
-        \textbf{Temores} & Lo que Javier más teme encontrarse es una documentación desorganizada, con un pobre nivel de expresión o llena de información innecesaria o irrelevante, sin unas fuentes fiables bien indicadas, ya que se tratará de un proyecto más difícil de estudiar y con menor valor. \\
-        \hline
-        \textbf{Necesidades} & Quiere una documentación organizada y clara, que demuestre buenos análisis para el problema a resolver y proponga soluciones de valor y justificadas. \\
-        \hline
-    \end{tabularx}
-\end{table}
-
 \subsection{\textit{User journeys}}
 
 Para crear una biblioteca y añadir libros:


### PR DESCRIPTION
Fixing a detail raised in #133 

I have removed every reference to the jury I found in the docs, what can be found in #7

The issue mentions a reference to the user story in the docs but I couldn't find it

Closes #133